### PR TITLE
Refactor galileo state to redux

### DIFF
--- a/src/lib/store/features/galileo/benchmarkSlice.ts
+++ b/src/lib/store/features/galileo/benchmarkSlice.ts
@@ -1,0 +1,155 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { FilterOptions, ActiveFilters, ApplyFiltersParams } from '@/pages/galileo/benchmark/filters';
+import { filterApi } from '@/pages/galileo/benchmark/filterApi';
+import { INITIAL_FILTER_OPTIONS } from '@/pages/galileo/benchmark/constants';
+
+export type ViewType = 'table' | 'chart';
+
+export interface TableData {
+  data: any[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface BenchmarkState {
+  filterOptions: FilterOptions | null;
+  activeFilters: ActiveFilters;
+  tableData: TableData | null;
+  isLoading: boolean;
+  isDownloading: boolean;
+  error: string | null;
+  hasAppliedFilters: boolean;
+  deselectedProjectIds: string[];
+  currentView: ViewType;
+  showChartsWithoutFilters: boolean;
+}
+
+const storedFilters = localStorage.getItem('galileoBenchmarkActiveFilters');
+
+const initialState: BenchmarkState = {
+  filterOptions: INITIAL_FILTER_OPTIONS,
+  activeFilters: storedFilters ? JSON.parse(storedFilters) : {},
+  tableData: null,
+  isLoading: false,
+  isDownloading: false,
+  error: null,
+  hasAppliedFilters: false,
+  deselectedProjectIds: [],
+  currentView: 'table',
+  showChartsWithoutFilters: false,
+};
+
+export const applyFilters = createAsyncThunk(
+  'benchmark/applyFilters',
+  async (params: ApplyFiltersParams) => {
+    const response = await filterApi.applyFilters(params);
+    return response;
+  }
+);
+
+export const fetchFilterOptions = createAsyncThunk(
+  'benchmark/fetchFilterOptions',
+  async () => {
+    const options = await filterApi.getFilterOptions();
+    if (!options.gfa) {
+      options.gfa = [];
+    }
+    return options;
+  }
+);
+
+export const downloadFilteredData = createAsyncThunk(
+  'benchmark/downloadFilteredData',
+  async (filters: ActiveFilters) => {
+    await filterApi.downloadFilteredData(filters);
+  }
+);
+
+const benchmarkSlice = createSlice({
+  name: 'benchmark',
+  initialState,
+  reducers: {
+    setActiveFilters(state, action: PayloadAction<ActiveFilters>) {
+      state.activeFilters = action.payload;
+      localStorage.setItem('galileoBenchmarkActiveFilters', JSON.stringify(action.payload));
+    },
+    clearFilters(state) {
+      state.activeFilters = {};
+      state.hasAppliedFilters = false;
+      state.deselectedProjectIds = [];
+      state.currentView = 'table';
+      localStorage.removeItem('galileoBenchmarkActiveFilters');
+    },
+    toggleProjectSelection(state, action: PayloadAction<{ projectId: string; selected: boolean }>) {
+      const { projectId, selected } = action.payload;
+      if (selected) {
+        state.deselectedProjectIds = state.deselectedProjectIds.filter((id) => id !== projectId);
+      } else {
+        if (!state.deselectedProjectIds.includes(projectId)) {
+          state.deselectedProjectIds.push(projectId);
+        }
+      }
+    },
+    resetSelection(state) {
+      state.deselectedProjectIds = [];
+    },
+    setCurrentView(state, action: PayloadAction<ViewType>) {
+      state.currentView = action.payload;
+    },
+    setShowChartsWithoutFilters(state, action: PayloadAction<boolean>) {
+      state.showChartsWithoutFilters = action.payload;
+    },
+    setHasAppliedFilters(state, action: PayloadAction<boolean>) {
+      state.hasAppliedFilters = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(applyFilters.pending, (state) => {
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(applyFilters.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.tableData = {
+          data: action.payload.data || [],
+          total: action.payload.total || 0,
+          page: action.payload.page || 1,
+          limit: action.payload.limit || 20,
+          totalPages: action.payload.totalPages || 1,
+        };
+        state.hasAppliedFilters = true;
+      })
+      .addCase(applyFilters.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = action.error.message || 'Error applying filters';
+      })
+      .addCase(fetchFilterOptions.fulfilled, (state, action) => {
+        state.filterOptions = action.payload;
+      })
+      .addCase(downloadFilteredData.pending, (state) => {
+        state.isDownloading = true;
+      })
+      .addCase(downloadFilteredData.fulfilled, (state) => {
+        state.isDownloading = false;
+      })
+      .addCase(downloadFilteredData.rejected, (state) => {
+        state.isDownloading = false;
+      });
+  },
+});
+
+export const {
+  setActiveFilters,
+  clearFilters,
+  toggleProjectSelection,
+  resetSelection,
+  setCurrentView,
+  setShowChartsWithoutFilters,
+  setHasAppliedFilters,
+} = benchmarkSlice.actions;
+
+export default benchmarkSlice.reducer;
+export type { TableData };

--- a/src/lib/store/features/galileo/searchSlice.ts
+++ b/src/lib/store/features/galileo/searchSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface SearchState {
+  projectId: string;
+  projectName: string;
+}
+
+const initialState: SearchState = {
+  projectId: '',
+  projectName: '',
+};
+
+const searchSlice = createSlice({
+  name: 'search',
+  initialState,
+  reducers: {
+    setProjectId(state, action: PayloadAction<string>) {
+      state.projectId = action.payload;
+    },
+    setProjectName(state, action: PayloadAction<string>) {
+      state.projectName = action.payload;
+    },
+  },
+});
+
+export const { setProjectId, setProjectName } = searchSlice.actions;
+export default searchSlice.reducer;

--- a/src/lib/store/store.ts
+++ b/src/lib/store/store.ts
@@ -2,6 +2,8 @@ import { configureStore } from '@reduxjs/toolkit';
 import authReducer from './features/auth/authSlice';
 import howtoReducer from './features/howto/howtoSlice';
 import methodologiesReducer from './methodologies/methodologiesSlice';
+import benchmarkReducer from './features/galileo/benchmarkSlice';
+import searchReducer from './features/galileo/searchSlice';
 import { useSelector, useDispatch } from 'react-redux';
 import { TypedUseSelectorHook } from 'react-redux';
 
@@ -10,6 +12,8 @@ const store = configureStore({
     auth: authReducer,
     howto: howtoReducer,
     methodologies: methodologiesReducer,
+    benchmark: benchmarkReducer,
+    search: searchReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/src/pages/galileo/benchmark/store/useBenchmarkStore.ts
+++ b/src/pages/galileo/benchmark/store/useBenchmarkStore.ts
@@ -1,205 +1,88 @@
-import { create } from 'zustand';
-import { devtools, persist } from 'zustand/middleware';
-import { ActiveFilters, FilterOptions } from '../filters';
-import { filterApi } from '../filterApi';
-import { FILTER_STORAGE_KEY, INITIAL_FILTER_OPTIONS } from '../constants';
+import { useCallback } from 'react';
+import { useAppDispatch, useAppSelector } from '@/lib/store/store';
+import {
+  ActiveFilters,
+  FilterOptions,
+} from '../filters';
+import {
+  applyFilters,
+  fetchFilterOptions,
+  downloadFilteredData,
+  setActiveFilters,
+  clearFilters,
+  toggleProjectSelection,
+  resetSelection,
+  setCurrentView,
+  setShowChartsWithoutFilters,
+  setHasAppliedFilters,
+  ViewType,
+} from '@/lib/store/features/galileo/benchmarkSlice';
 
-// Types
-export type ViewType = 'table' | 'chart';
+export const useBenchmarkStore = () => {
+  const dispatch = useAppDispatch();
+  const state = useAppSelector((s) => s.benchmark);
 
-export interface TableData {
-  data: any[];
-  total: number;
-  page: number;
-  limit: number;
-  totalPages: number;
-}
-
-export interface BenchmarkState {
-  // State
-  filterOptions: FilterOptions | null;
-  activeFilters: ActiveFilters;
-  tableData: TableData | null;
-  isLoading: boolean;
-  isDownloading: boolean;
-  error: Error | null;
-  hasAppliedFilters: boolean;
-  deselectedProjectIds: string[];
-  currentView: ViewType;
-  showChartsWithoutFilters: boolean;
-  
-  // Actions
-  setActiveFilters: (filters: ActiveFilters) => void;
-  clearFilters: () => void;
-  applyFilters: (page?: number) => Promise<TableData>;
-  downloadFilteredData: () => Promise<void>;
-  toggleProjectSelection: (projectId: string, selected: boolean) => void;
-  isProjectSelected: (projectId: string) => boolean;
-  resetSelection: () => void;
-  setCurrentView: (view: ViewType) => void;
-  setShowChartsWithoutFilters: (show: boolean) => void;
-  initializeFromURL: (urlFilters: ActiveFilters, urlDeselected: string[], view?: ViewType) => Promise<void>;
-}
-
-// Store implementation
-const useBenchmarkStore = create<BenchmarkState>()(
-  devtools(
-    persist(
-      (set, get) => ({
-        // Initial state
-        filterOptions: INITIAL_FILTER_OPTIONS,
-        activeFilters: {},
-        tableData: null,
-        isLoading: false,
-        isDownloading: false,
-        error: null,
-        hasAppliedFilters: false,
-        deselectedProjectIds: [],
-        currentView: 'table',
-        showChartsWithoutFilters: false,
-
-        // Actions
-        setActiveFilters: (filters) => set({ activeFilters: filters }),
-        
-        clearFilters: () => {
-          localStorage.removeItem(FILTER_STORAGE_KEY);
-          set({
-            activeFilters: {},
-            hasAppliedFilters: false,
-            currentView: 'table',
-            deselectedProjectIds: [],
-          });
-        },
-
-        toggleProjectSelection: (projectId, selected) => {
-          set((state) => {
-            if (selected) {
-              return {
-                deselectedProjectIds: state.deselectedProjectIds.filter((id) => id !== projectId),
-              };
-            } else {
-              return {
-                deselectedProjectIds: state.deselectedProjectIds.includes(projectId)
-                  ? state.deselectedProjectIds
-                  : [...state.deselectedProjectIds, projectId],
-              };
-            }
-          });
-        },
-
-        isProjectSelected: (projectId) => {
-          return !get().deselectedProjectIds.includes(projectId);
-        },
-
-        resetSelection: () => {
-          set({ deselectedProjectIds: [] });
-        },
-
-        setCurrentView: (view) => set({ currentView: view }),
-        
-        setShowChartsWithoutFilters: (show) => set({ showChartsWithoutFilters: show }),
-
-        initializeFromURL: async (urlFilters, urlDeselected, view = 'table') => {
-          try {
-            // Set initial state from URL
-            set({
-              activeFilters: Object.keys(urlFilters).length > 0 ? urlFilters : {},
-              deselectedProjectIds: urlDeselected || [],
-              currentView: view,
-              hasAppliedFilters: Object.keys(urlFilters).length > 0,
-            });
-
-            // Fetch filter options
-            const options = await filterApi.getFilterOptions();
-            if (!options.gfa) {
-              options.gfa = [];
-            }
-
-            set({ filterOptions: options });
-
-            // Apply filters if we have URL filters
-            if (Object.keys(urlFilters).length > 0) {
-              await get().applyFilters(1);
-            }
-          } catch (err) {
-            console.error('Error initializing from URL:', err);
-            set({ error: err as Error });
-          }
-        },
-
-        applyFilters: async (page = 1) => {
-          const { activeFilters: currentFilters } = get();
-          
-          try {
-            set({ isLoading: true, error: null });
-
-            const response = await filterApi.applyFilters({
-              filters: currentFilters,
-              page,
-            });
-
-            const newTableData: TableData = {
-              data: response.data || [],
-              total: response.total || 0,
-              page: response.page || 1,
-              limit: response.limit || 20,
-              totalPages: response.totalPages || 1,
-            };
-
-
-            set({
-              tableData: newTableData,
-              hasAppliedFilters: true,
-            });
-
-            // Only fetch filter options if we haven't already or if the data has changed
-            if (!get().filterOptions || response.data.length > 0) {
-              const options = await filterApi.getFilterOptions();
-              if (!options.gfa) {
-                options.gfa = [];
-              }
-              set({ filterOptions: options });
-            }
-
-            return newTableData;
-          } catch (err) {
-            console.error('Error applying filters:', err);
-            const errorState = { 
-              error: err as Error,
-              tableData: { data: [], total: 0, page: 1, limit: 20, totalPages: 1 }
-            };
-            set(errorState);
-            return errorState.tableData;
-          } finally {
-            set({ isLoading: false });
-          }
-        },
-
-        downloadFilteredData: async () => {
-          try {
-            set({ isDownloading: true });
-            await filterApi.downloadFilteredData(get().activeFilters);
-          } catch (err) {
-            console.error('Error downloading filtered data:', err);
-            set({ error: err as Error });
-          } finally {
-            set({ isDownloading: false });
-          }
-        },
-      }),
-      {
-        name: 'benchmark-storage',
-        partialize: (state) => ({
-          activeFilters: state.activeFilters,
-          deselectedProjectIds: state.deselectedProjectIds,
-          currentView: state.currentView,
-        }),
+  const initializeFromURL = useCallback(
+    async (
+      urlFilters: ActiveFilters,
+      urlDeselected: string[],
+      view: ViewType = 'table'
+    ) => {
+      dispatch(setActiveFilters(Object.keys(urlFilters).length > 0 ? urlFilters : {}));
+      dispatch(setCurrentView(view));
+      dispatch(setHasAppliedFilters(Object.keys(urlFilters).length > 0));
+      if (urlDeselected && urlDeselected.length > 0) {
+        urlDeselected.forEach((id) =>
+          dispatch(toggleProjectSelection({ projectId: id, selected: false }))
+        );
       }
-    ),
-    {
-      name: 'BenchmarkStore',
-    }
-  )
-);
+      await dispatch(fetchFilterOptions()).unwrap();
+      if (Object.keys(urlFilters).length > 0) {
+        await dispatch(applyFilters({ filters: urlFilters, page: 1 })).unwrap();
+      }
+    },
+    [dispatch]
+  );
+
+  const applyFiltersAction = useCallback(
+    async (page?: number) => {
+      return dispatch(applyFilters({ filters: state.activeFilters, page: page || 1 })).unwrap();
+    },
+    [dispatch, state.activeFilters]
+  );
+
+  const downloadFilteredDataAction = useCallback(async () => {
+    await dispatch(downloadFilteredData(state.activeFilters));
+  }, [dispatch, state.activeFilters]);
+
+  const toggleProjectSelectionAction = useCallback(
+    (projectId: string, selected: boolean) => {
+      dispatch(toggleProjectSelection({ projectId, selected }));
+    },
+    [dispatch]
+  );
+
+  const isProjectSelected = useCallback(
+    (projectId: string) => !state.deselectedProjectIds.includes(projectId),
+    [state.deselectedProjectIds]
+  );
+
+  return {
+    ...state,
+    setActiveFilters: (filters: ActiveFilters) => dispatch(setActiveFilters(filters)),
+    clearFilters: () => dispatch(clearFilters()),
+    applyFilters: applyFiltersAction,
+    downloadFilteredData: downloadFilteredDataAction,
+    toggleProjectSelection: toggleProjectSelectionAction,
+    isProjectSelected,
+    resetSelection: () => dispatch(resetSelection()),
+    setCurrentView: (view: ViewType) => dispatch(setCurrentView(view)),
+    setShowChartsWithoutFilters: (show: boolean) => dispatch(setShowChartsWithoutFilters(show)),
+    initializeFromURL,
+  };
+};
+
+export type { ViewType, FilterOptions } from '../filters';
+export type { TableData } from '@/lib/store/features/galileo/benchmarkSlice';
 
 export default useBenchmarkStore;

--- a/src/pages/galileo/search/context/SearchContext.tsx
+++ b/src/pages/galileo/search/context/SearchContext.tsx
@@ -1,93 +1,54 @@
-import { createContext, useContext, useState, useEffect } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
-
-interface SearchContextType {
-  projectId: string;
-  setProjectId: (id: string) => void;
-  projectName: string;
-  setProjectName: (name: string) => void;
-  getShareableLink: () => string;
-}
-
-const SearchContext = createContext<SearchContextType | undefined>(undefined);
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useAppDispatch, useAppSelector } from '@/lib/store/store';
+import { setProjectId, setProjectName } from '@/lib/store/features/galileo/searchSlice';
 
 export const SearchProvider = ({ children }: { children: React.ReactNode }) => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const projectId = useAppSelector((s) => s.search.projectId);
+  const projectName = useAppSelector((s) => s.search.projectName);
 
-  // Initialize state from URL parameters if available
-  const initialProjectId = searchParams.get('projectId') || '';
-  const initialProjectName = searchParams.get('projectName') || '';
-
-  const [projectId, setProjectIdState] = useState(initialProjectId);
-  const [projectName, setProjectNameState] = useState(initialProjectName);
-
-  // Custom setters that update both state and URL parameters
-  const setProjectId = (id: string) => {
-    setProjectIdState(id);
-    if (id) {
-      searchParams.set('projectId', id);
-    } else {
-      searchParams.delete('projectId');
-    }
-    setSearchParams(searchParams);
-  };
-
-  const setProjectName = (name: string) => {
-    setProjectNameState(name);
-    if (name) {
-      searchParams.set('projectName', name);
-    } else {
-      searchParams.delete('projectName');
-    }
-    setSearchParams(searchParams);
-  };
-
-  // Effect to handle initial URL parameters
   useEffect(() => {
-    // If we have a projectId in the URL but no projectName, we might need to fetch the project details
-    if (initialProjectId && !initialProjectName) {
-      // You could add an API call here to fetch the project name if needed
-      // console.log('Project ID in URL but no name, could fetch project details here');
-    }
-  }, [initialProjectId, initialProjectName]);
+    const id = searchParams.get('projectId') || '';
+    const name = searchParams.get('projectName') || '';
+    dispatch(setProjectId(id));
+    dispatch(setProjectName(name));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  // Helper function to get a shareable link with the current project
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (projectId) params.set('projectId', projectId);
+    if (projectName) params.set('projectName', projectName);
+    setSearchParams(params);
+  }, [projectId, projectName, setSearchParams]);
+
+  return <>{children}</>;
+};
+
+export const useSearchContext = () => {
+  const dispatch = useAppDispatch();
+  const projectId = useAppSelector((s) => s.search.projectId);
+  const projectName = useAppSelector((s) => s.search.projectName);
+
+  const setProjectIdHandler = (id: string) => dispatch(setProjectId(id));
+  const setProjectNameHandler = (name: string) => dispatch(setProjectName(name));
+
   const getShareableLink = () => {
     const baseUrl = window.location.origin + '/galileo/search';
     const params = new URLSearchParams();
-
-    if (projectId) {
-      params.set('projectId', projectId);
-    }
-
-    if (projectName) {
-      params.set('projectName', projectName);
-    }
-
+    if (projectId) params.set('projectId', projectId);
+    if (projectName) params.set('projectName', projectName);
     const queryString = params.toString();
     return queryString ? `${baseUrl}?${queryString}` : baseUrl;
   };
 
-  return (
-    <SearchContext.Provider
-      value={{
-        projectId,
-        setProjectId,
-        projectName,
-        setProjectName,
-        getShareableLink,
-      }}
-    >
-      {children}
-    </SearchContext.Provider>
-  );
-};
-
-export const useSearchContext = () => {
-  const context = useContext(SearchContext);
-  if (!context) {
-    throw new Error('useSearchContext must be used within a SearchProvider');
-  }
-  return context;
+  return {
+    projectId,
+    setProjectId: setProjectIdHandler,
+    projectName,
+    setProjectName: setProjectNameHandler,
+    getShareableLink,
+  };
 };


### PR DESCRIPTION
## Summary
- create `benchmarkSlice` and `searchSlice` for galileo features
- hook the new slices into the store
- rewrite benchmark and search hooks to use Redux state
- keep URL sync logic in providers

## Testing
- `npm test -- --passWithNoTests`
