### PR TITLE
Fix selection sync across pages and sidebar state

### DIFF
--- a/src/lib/store/features/galileo/benchmarkSlice.ts
+++ b/src/lib/store/features/galileo/benchmarkSlice.ts
@@ -22,6 +22,8 @@ export interface BenchmarkState {
   error: string | null;
   hasAppliedFilters: boolean;
   deselectedProjectIds: string[];
+  selectedProjectIds: string[];
+  isAllSelected: boolean;
   currentView: ViewType;
   showChartsWithoutFilters: boolean;
 }
@@ -37,6 +39,8 @@ const initialState: BenchmarkState = {
   error: null,
   hasAppliedFilters: false,
   deselectedProjectIds: [],
+  selectedProjectIds: [],
+  isAllSelected: true,
   currentView: 'table',
   showChartsWithoutFilters: false,
 };
@@ -79,21 +83,38 @@ const benchmarkSlice = createSlice({
       state.activeFilters = {};
       state.hasAppliedFilters = false;
       state.deselectedProjectIds = [];
+      state.selectedProjectIds = [];
+      state.isAllSelected = true;
       state.currentView = 'table';
       localStorage.removeItem('galileoBenchmarkActiveFilters');
     },
     toggleProjectSelection(state, action: PayloadAction<{ projectId: string; selected: boolean }>) {
       const { projectId, selected } = action.payload;
-      if (selected) {
-        state.deselectedProjectIds = state.deselectedProjectIds.filter((id) => id !== projectId);
-      } else {
-        if (!state.deselectedProjectIds.includes(projectId)) {
+      if (state.isAllSelected) {
+        if (selected) {
+          state.deselectedProjectIds = state.deselectedProjectIds.filter((id) => id !== projectId);
+        } else if (!state.deselectedProjectIds.includes(projectId)) {
           state.deselectedProjectIds.push(projectId);
+        }
+      } else {
+        if (selected) {
+          if (!state.selectedProjectIds.includes(projectId)) {
+            state.selectedProjectIds.push(projectId);
+          }
+        } else {
+          state.selectedProjectIds = state.selectedProjectIds.filter((id) => id !== projectId);
         }
       }
     },
     resetSelection(state) {
       state.deselectedProjectIds = [];
+      state.selectedProjectIds = [];
+      state.isAllSelected = true;
+    },
+    setSelectAll(state, action: PayloadAction<boolean>) {
+      state.isAllSelected = action.payload;
+      state.deselectedProjectIds = [];
+      state.selectedProjectIds = [];
     },
     setCurrentView(state, action: PayloadAction<ViewType>) {
       state.currentView = action.payload;
@@ -146,6 +167,7 @@ export const {
   clearFilters,
   toggleProjectSelection,
   resetSelection,
+  setSelectAll,
   setCurrentView,
   setShowChartsWithoutFilters,
   setHasAppliedFilters,

--- a/src/pages/galileo/benchmark/components/BenchmarkTable/ProjectTable.tsx
+++ b/src/pages/galileo/benchmark/components/BenchmarkTable/ProjectTable.tsx
@@ -18,7 +18,14 @@ const TableHeaderNamesMapConfig: Record<string, string> = {
 };
 
 const ProjectTable: React.FC<ProjectTableProps> = ({ projects, onSelectionChange }) => {
-  const { isProjectSelected, resetSelection, deselectedProjectIds } = useBenchmark();
+  const {
+    isProjectSelected,
+    resetSelection,
+    deselectedProjectIds,
+    selectedProjectIds,
+    isAllSelected,
+    setSelectAll,
+  } = useBenchmark();
   // Get all unique column keys from the projects
   const columnKeys = React.useMemo(() => {
     const keys = new Set<string>();
@@ -99,30 +106,19 @@ const ProjectTable: React.FC<ProjectTableProps> = ({ projects, onSelectionChange
               <input
                 type="checkbox"
                 className="project-selection__checkbox"
-                checked={projects.length > 0 && deselectedProjectIds.length === 0}
+                checked={isAllSelected}
                 ref={(el) => {
                   if (el) {
-                    // Indeterminate state when some projects are deselected but not all
-                    el.indeterminate =
-                      deselectedProjectIds.length > 0 &&
-                      deselectedProjectIds.length < projects.length;
+                    el.indeterminate = isAllSelected
+                      ? deselectedProjectIds.length > 0
+                      : selectedProjectIds.length > 0;
                   }
                 }}
                 onChange={(e) => {
-                  // Handle select all / deselect all
                   const isChecked = e.target.checked;
-                  // console.log('Select all:', isChecked);
-
+                  setSelectAll(isChecked);
                   if (isChecked) {
-                    // Select all projects (clear deselected list)
                     resetSelection();
-                    // console.log('Selected all projects');
-                  } else {
-                    // Deselect all projects (add all to deselected list)
-                    projects.forEach((project) => {
-                      onSelectionChange(project, false);
-                    });
-                    // console.log('Deselected all projects');
                   }
                 }}
                 aria-label="Select all projects"

--- a/src/pages/galileo/benchmark/hooks/useBenchmark.ts
+++ b/src/pages/galileo/benchmark/hooks/useBenchmark.ts
@@ -12,6 +12,8 @@ export const useBenchmark = () => {
     error,
     hasAppliedFilters,
     deselectedProjectIds,
+    selectedProjectIds,
+    isAllSelected,
     currentView,
     showChartsWithoutFilters,
     
@@ -23,6 +25,7 @@ export const useBenchmark = () => {
     toggleProjectSelection,
     isProjectSelected,
     resetSelection,
+    setSelectAll,
     setCurrentView,
     setShowChartsWithoutFilters,
   } = useBenchmarkStore();
@@ -61,6 +64,8 @@ export const useBenchmark = () => {
     error,
     hasAppliedFilters,
     deselectedProjectIds,
+    selectedProjectIds,
+    isAllSelected,
     currentView,
     showChartsWithoutFilters,
     
@@ -72,6 +77,7 @@ export const useBenchmark = () => {
     toggleProjectSelection: toggleProjectSelectionHandler,
     isProjectSelected: isProjectSelectedHandler,
     resetSelection,
+    setSelectAll,
     setCurrentView,
     setShowChartsWithoutFilters,
   };

--- a/src/pages/galileo/benchmark/store/useBenchmarkStore.ts
+++ b/src/pages/galileo/benchmark/store/useBenchmarkStore.ts
@@ -12,6 +12,7 @@ import {
   setCurrentView,
   setShowChartsWithoutFilters,
   setHasAppliedFilters,
+  setSelectAll,
   ViewType,
 } from '@/lib/store/features/galileo/benchmarkSlice';
 
@@ -56,8 +57,13 @@ export const useBenchmarkStore = () => {
   );
 
   const isProjectSelected = useCallback(
-    (projectId: string) => !state.deselectedProjectIds.includes(projectId),
-    [state.deselectedProjectIds]
+    (projectId: string) => {
+      if (state.isAllSelected) {
+        return !state.deselectedProjectIds.includes(projectId);
+      }
+      return state.selectedProjectIds.includes(projectId);
+    },
+    [state.deselectedProjectIds, state.selectedProjectIds, state.isAllSelected]
   );
 
   return {
@@ -69,6 +75,7 @@ export const useBenchmarkStore = () => {
     toggleProjectSelection: toggleProjectSelectionAction,
     isProjectSelected,
     resetSelection: () => dispatch(resetSelection()),
+    setSelectAll: (val: boolean) => dispatch(setSelectAll(val)),
     setCurrentView: (view: ViewType) => dispatch(setCurrentView(view)),
     setShowChartsWithoutFilters: (show: boolean) => dispatch(setShowChartsWithoutFilters(show)),
     initializeFromURL,


### PR DESCRIPTION
## Summary
- enhance benchmark slice to track selected projects and global select state
- expose new state/action via hooks
- update project table to use the global select state

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: many prettier errors)*