### PR TITLE
Fix filter dropdown state persistence

### DIFF
--- a/src/einstein/components/howto/components/howToDropdown/HowToDropdown.tsx
+++ b/src/einstein/components/howto/components/howToDropdown/HowToDropdown.tsx
@@ -20,12 +20,17 @@ const HowToDropdown = ({
   // Initialize with empty string instead of defaulting to first option
   const [selectedValue, setSelectedValue] = useState(externalSelectedValue || '');
 
-  // Update internal state when external value changes
+  // Keep internal state in sync with external value
   useEffect(() => {
-    if (externalSelectedValue !== undefined) {
-      setSelectedValue(externalSelectedValue);
-    }
+    setSelectedValue(externalSelectedValue || '');
   }, [externalSelectedValue]);
+
+  // Reset selection if current value no longer exists in options
+  useEffect(() => {
+    if (selectedValue && !options.some((option) => option.value === selectedValue)) {
+      setSelectedValue('');
+    }
+  }, [options, selectedValue]);
 
   const handleValueChange = (value: string) => {
     // Check if the selected option is disabled


### PR DESCRIPTION
## Summary
- keep `HowToDropdown` state in sync with props
- clear selection when options change

## Testing
- `npm test --silent`
- `npx eslint src/einstein/components/howto/components/howToDropdown/HowToDropdown.tsx`