### PR TITLE
Add scatter chart display toggle

### DIFF
--- a/src/pages/galileo/benchmark/components/MicroChartView/ChartWrapper.tsx
+++ b/src/pages/galileo/benchmark/components/MicroChartView/ChartWrapper.tsx
@@ -6,6 +6,7 @@ import { CustomBarChartWithPhases } from './CustomBarChartWithPhases';
 import { CustomGanttChart } from './CustomGanttChart';
 import { CustomTimelineGanttChart } from './CustomTimelineGanttChart';
 import { NoDataMessage } from './NoDataMessage';
+import { ScatterDisplayMode } from './ScatterChartControls';
 
 interface BarChartWrapperProps {
   data: any[];
@@ -120,9 +121,10 @@ export const BarChartWrapper: React.FC<BarChartWrapperProps> = ({
 interface ScatterChartWrapperProps {
   data: any[];
   className?: string;
+  displayMode?: ScatterDisplayMode;
 }
 
-export const ScatterChartWrapper: React.FC<ScatterChartWrapperProps> = ({ data, className }) => {
+export const ScatterChartWrapper: React.FC<ScatterChartWrapperProps> = ({ data, className, displayMode = 'both' }) => {
   const { isFullscreen } = useFullscreen();
   const wrapperRef = React.useRef<HTMLDivElement>(null);
   const [key, setKey] = React.useState(0);
@@ -203,6 +205,7 @@ export const ScatterChartWrapper: React.FC<ScatterChartWrapperProps> = ({ data, 
         <CustomScatterChart
           data={data}
           isPreview={!isFullscreen}
+          displayMode={displayMode}
           key={`scatter-chart-${isFullscreen ? 'fullscreen' : 'preview'}-${key}`} // Force remount on fullscreen toggle and key change
         />
       </div>

--- a/src/pages/galileo/benchmark/components/MicroChartView/CustomScatterChart.tsx
+++ b/src/pages/galileo/benchmark/components/MicroChartView/CustomScatterChart.tsx
@@ -16,6 +16,7 @@ interface ScatterplotData {
 interface ScatterplotChartProps {
   data: ScatterplotData[] | null;
   isPreview?: boolean;
+  displayMode?: 'both' | 'planned' | 'actual';
 }
 
 // Define point colors
@@ -27,6 +28,7 @@ const POINT_COLORS = {
 export const CustomScatterChart: React.FC<ScatterplotChartProps> = ({
   data,
   isPreview = false,
+  displayMode = 'both',
 }) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -233,58 +235,66 @@ export const CustomScatterChart: React.FC<ScatterplotChartProps> = ({
       });
 
       // Add regression line for planned (dashed)
-      plotArea
-        .append('line')
-        .attr('class', 'regression-line planned')
-        .attr('x1', xScale(plannedLinePoints[0].x))
-        .attr('y1', yScale(plannedLinePoints[0].y))
-        .attr('x2', xScale(plannedLinePoints[1].x))
-        .attr('y2', yScale(plannedLinePoints[1].y))
-        .attr('stroke', POINT_COLORS.planned)
-        .attr('stroke-width', 2)
-        .attr('stroke-dasharray', '5,5')
-        .style('opacity', 0.7);
+      if (displayMode !== 'actual') {
+        plotArea
+          .append('line')
+          .attr('class', 'regression-line planned')
+          .attr('x1', xScale(plannedLinePoints[0].x))
+          .attr('y1', yScale(plannedLinePoints[0].y))
+          .attr('x2', xScale(plannedLinePoints[1].x))
+          .attr('y2', yScale(plannedLinePoints[1].y))
+          .attr('stroke', POINT_COLORS.planned)
+          .attr('stroke-width', 2)
+          .attr('stroke-dasharray', '5,5')
+          .style('opacity', 0.7);
+      }
 
       // Add regression line for actual (dashed)
-      plotArea
-        .append('line')
-        .attr('class', 'regression-line actual')
-        .attr('x1', xScale(actualLinePoints[0].x))
-        .attr('y1', yScale(actualLinePoints[0].y))
-        .attr('x2', xScale(actualLinePoints[1].x))
-        .attr('y2', yScale(actualLinePoints[1].y))
-        .attr('stroke', POINT_COLORS.actual)
-        .attr('stroke-width', 2)
-        .attr('stroke-dasharray', '5,5')
-        .style('opacity', 0.7);
+      if (displayMode !== 'planned') {
+        plotArea
+          .append('line')
+          .attr('class', 'regression-line actual')
+          .attr('x1', xScale(actualLinePoints[0].x))
+          .attr('y1', yScale(actualLinePoints[0].y))
+          .attr('x2', xScale(actualLinePoints[1].x))
+          .attr('y2', yScale(actualLinePoints[1].y))
+          .attr('stroke', POINT_COLORS.actual)
+          .attr('stroke-width', 2)
+          .attr('stroke-dasharray', '5,5')
+          .style('opacity', 0.7);
+      }
 
       // Add scatter points for planned duration
-      plotArea
-        .selectAll('.planned-point')
-        .data(data)
-        .enter()
-        .append('circle')
-        .attr('class', 'planned-point')
-        .attr('cx', (d) => xScale(d.planned))
-        .attr('cy', (d) => yScale(d.gfa))
-        .attr('r', isPreview ? 6 : 8)
-        .attr('fill', POINT_COLORS.planned)
-        .attr('stroke', 'white')
-        .attr('stroke-width', 2);
+      if (displayMode !== 'actual') {
+        plotArea
+          .selectAll('.planned-point')
+          .data(data)
+          .enter()
+          .append('circle')
+          .attr('class', 'planned-point')
+          .attr('cx', (d) => xScale(d.planned))
+          .attr('cy', (d) => yScale(d.gfa))
+          .attr('r', isPreview ? 6 : 8)
+          .attr('fill', POINT_COLORS.planned)
+          .attr('stroke', 'white')
+          .attr('stroke-width', 2);
+      }
 
       // Add scatter points for actual duration
-      plotArea
-        .selectAll('.actual-point')
-        .data(data)
-        .enter()
-        .append('circle')
-        .attr('class', 'actual-point')
-        .attr('cx', (d) => xScale(d.actual))
-        .attr('cy', (d) => yScale(d.gfa))
-        .attr('r', isPreview ? 6 : 8)
-        .attr('fill', POINT_COLORS.actual)
-        .attr('stroke', 'white')
-        .attr('stroke-width', 2);
+      if (displayMode !== 'planned') {
+        plotArea
+          .selectAll('.actual-point')
+          .data(data)
+          .enter()
+          .append('circle')
+          .attr('class', 'actual-point')
+          .attr('cx', (d) => xScale(d.actual))
+          .attr('cy', (d) => yScale(d.gfa))
+          .attr('r', isPreview ? 6 : 8)
+          .attr('fill', POINT_COLORS.actual)
+          .attr('stroke', 'white')
+          .attr('stroke-width', 2);
+      }
 
       // Add X axis with better positioning
       const xAxis = g
@@ -505,28 +515,36 @@ export const CustomScatterChart: React.FC<ScatterplotChartProps> = ({
             });
 
           // Update point positions
-          plotArea
-            .selectAll('.planned-point')
-            .attr('cx', (d: any) => newXScale(d.planned))
-            .attr('cy', (d: any) => newYScale(d.gfa));
-          plotArea
-            .selectAll('.actual-point')
-            .attr('cx', (d: any) => newXScale(d.actual))
-            .attr('cy', (d: any) => newYScale(d.gfa));
+          if (displayMode !== 'actual') {
+            plotArea
+              .selectAll('.planned-point')
+              .attr('cx', (d: any) => newXScale(d.planned))
+              .attr('cy', (d: any) => newYScale(d.gfa));
+          }
+          if (displayMode !== 'planned') {
+            plotArea
+              .selectAll('.actual-point')
+              .attr('cx', (d: any) => newXScale(d.actual))
+              .attr('cy', (d: any) => newYScale(d.gfa));
+          }
 
           // Update regression lines
-          plotArea
-            .select('.regression-line.planned')
-            .attr('x1', newXScale(plannedLinePoints[0].x))
-            .attr('y1', newYScale(plannedLinePoints[0].y))
-            .attr('x2', newXScale(plannedLinePoints[1].x))
-            .attr('y2', newYScale(plannedLinePoints[1].y));
-          plotArea
-            .select('.regression-line.actual')
-            .attr('x1', newXScale(actualLinePoints[0].x))
-            .attr('y1', newYScale(actualLinePoints[0].y))
-            .attr('x2', newXScale(actualLinePoints[1].x))
-            .attr('y2', newYScale(actualLinePoints[1].y));
+          if (displayMode !== 'actual') {
+            plotArea
+              .select('.regression-line.planned')
+              .attr('x1', newXScale(plannedLinePoints[0].x))
+              .attr('y1', newYScale(plannedLinePoints[0].y))
+              .attr('x2', newXScale(plannedLinePoints[1].x))
+              .attr('y2', newYScale(plannedLinePoints[1].y));
+          }
+          if (displayMode !== 'planned') {
+            plotArea
+              .select('.regression-line.actual')
+              .attr('x1', newXScale(actualLinePoints[0].x))
+              .attr('y1', newYScale(actualLinePoints[0].y))
+              .attr('x2', newXScale(actualLinePoints[1].x))
+              .attr('y2', newYScale(actualLinePoints[1].y));
+          }
 
           // Update grid lines
           g.selectAll('.grid line.x-grid')
@@ -561,10 +579,18 @@ export const CustomScatterChart: React.FC<ScatterplotChartProps> = ({
       });
 
       // Make scatter points pointer-events visible
-      plotArea
-        .selectAll('.planned-point, .actual-point')
-        .style('pointer-events', 'visible')
-        .style('cursor', 'pointer');
+      const pointSelector = [
+        displayMode !== 'actual' ? '.planned-point' : null,
+        displayMode !== 'planned' ? '.actual-point' : null,
+      ]
+        .filter(Boolean)
+        .join(', ');
+      if (pointSelector) {
+        plotArea
+          .selectAll(pointSelector)
+          .style('pointer-events', 'visible')
+          .style('cursor', 'pointer');
+      }
     };
 
     updateChart();
@@ -617,7 +643,7 @@ export const CustomScatterChart: React.FC<ScatterplotChartProps> = ({
         }
       }, 50);
     };
-  }, [data, isPreview]);
+  }, [data, isPreview, displayMode]);
 
   // If there's no data, show the NoDataMessage component
   if (!data || data.length === 0) {

--- a/src/pages/galileo/benchmark/components/MicroChartView/ScatterChartControls.tsx
+++ b/src/pages/galileo/benchmark/components/MicroChartView/ScatterChartControls.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { SegmentedMenu, SegmentedControlItem } from '@/components/segmented-menu/SegmentedMenu';
+import { useFullscreen } from '@/components/toggle-fullscreen/ToggleFullscreenContext';
+
+export type ScatterDisplayMode = 'both' | 'planned' | 'actual';
+
+interface ScatterChartControlsProps {
+  value: ScatterDisplayMode;
+  onChange: (value: ScatterDisplayMode) => void;
+}
+
+const items: SegmentedControlItem[] = [
+  { id: 'both', label: 'Both' },
+  { id: 'planned', label: 'Planned' },
+  { id: 'actual', label: 'Actual' },
+];
+
+const ScatterChartControls: React.FC<ScatterChartControlsProps> = ({ value, onChange }) => {
+  const { isFullscreen } = useFullscreen();
+
+  if (!isFullscreen) {
+    return null;
+  }
+
+  const handleChange = (item: SegmentedControlItem) => {
+    onChange(item.id as ScatterDisplayMode);
+  };
+
+  return (
+    <SegmentedMenu
+      items={items}
+      defaultActiveId={value}
+      onChange={handleChange}
+      className="scatter-chart-controls"
+    />
+  );
+};
+
+export default ScatterChartControls;

--- a/src/pages/galileo/benchmark/components/MicroChartView/index.tsx
+++ b/src/pages/galileo/benchmark/components/MicroChartView/index.tsx
@@ -6,7 +6,9 @@ import { FullscreenProvider } from '@/components/toggle-fullscreen/ToggleFullscr
 import ChartHeader from '../chart/ChartHeader';
 import { ToggleFullscreen } from '@/components/toggle-fullscreen';
 import { BarChartWrapper, ScatterChartWrapper, GanttChartWrapper } from './ChartWrapper';
+import ScatterChartControls, { ScatterDisplayMode } from './ScatterChartControls';
 import ChartToolbar from './ChartToolbar';
+import BaseChartToolbar from '../chart/ChartToolbar';
 import { SegmentedControlItem } from '@/components/segmented-menu/SegmentedMenu';
 import '../chart/ChartLayout.scss';
 import './ChartOverrides.scss'; // Import custom styles for all chart types
@@ -41,6 +43,7 @@ const MicroChartView: React.FC = () => {
   const [ganttChartData, setGanttChartData] = useState<any[]>([]);
   const [error, setError] = useState<Error | null>(null);
   const [barChartType, setBarChartType] = useState<string>('bar'); // Default to spike chart
+  const [scatterDisplayMode, setScatterDisplayMode] = useState<ScatterDisplayMode>('both');
 
   useEffect(() => {
     const fetchChartData = async () => {
@@ -106,6 +109,10 @@ const MicroChartView: React.FC = () => {
   // Handle bar chart type change
   const handleBarChartTypeChange = (item: SegmentedControlItem) => {
     setBarChartType(item.id);
+  };
+
+  const handleScatterDisplayModeChange = (mode: ScatterDisplayMode) => {
+    setScatterDisplayMode(mode);
   };
 
   // Get legend data (same for both chart types now)
@@ -203,9 +210,22 @@ const MicroChartView: React.FC = () => {
                       description="Analysing the relationship between project duration and GFA"
                     />
                   }
+                  toolbar={
+                    <BaseChartToolbar
+                      tools={
+                        <ScatterChartControls
+                          value={scatterDisplayMode}
+                          onChange={handleScatterDisplayModeChange}
+                        />
+                      }
+                    />
+                  }
                   chart={
                     <div className="micro-chart-view__chart-content">
-                      <ScatterChartWrapper data={scatterChartData} />
+                      <ScatterChartWrapper
+                        data={scatterChartData}
+                        displayMode={scatterDisplayMode}
+                      />
                     </div>
                   }
                   legend={


### PR DESCRIPTION
## Summary
- add segmented controls for scatter chart to switch between data sets
- conditionally draw regression lines and points based on selected mode
- update wrapper and chart layout to wire up controls

## Testing
- `npm test`
- `npm run lint` *(fails: prettier errors)*