### PR TITLE
Add Playwright auth bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,25 @@ npm start
 - `npm run lint` - Runs ESLint
 - `npm run format` - Formats code with Prettier
 
+## End-to-End Testing
+
+The project uses **Playwright** for e2e tests. Before running the tests, install
+the Playwright browsers:
+
+```bash
+npx playwright install
+```
+
+Authentication is disabled during tests via the `REACT_APP_ENABLE_AUTH=false`
+environment variable. Run the test suite with:
+
+```bash
+npm run test:e2e
+```
+
+This starts the dev server with auth disabled and executes the Playwright test
+suite.
+
 ## Architecture
 
 The application follows a modern React architecture with:

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "sass": "1.86.0",
     "tailwindcss": "3.3.2",
     "typescript": "5.6.2",
-    "typescript-eslint": "^8.0.0"
+    "typescript-eslint": "^8.0.0",
+    "@playwright/test": "^1.43.1"
   },
   "scripts": {
     "start": "craco start",
@@ -91,7 +92,8 @@
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "serve": "serve -s build",
     "start:prod": "npm run serve",
-    "build:prod": "npm run build && npm run start:prod"
+    "build:prod": "npm run build && npm run start:prod",
+    "test:e2e": "playwright test"
   },
   "eslintConfig": {
     "extends": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30000,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+  webServer: {
+    command: 'npm start',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    env: {
+      REACT_APP_ENABLE_AUTH: 'false',
+    },
+  },
+});

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+const cardTitles = [
+  'Curiosity',
+  'Methods',
+  'Maps',
+  'Galileo',
+  'Abacus-Cost',
+  'How To',
+];
+
+test.describe('Dashboard page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('renders all dashboard cards', async ({ page }) => {
+    for (const title of cardTitles) {
+      await expect(page.getByText(title)).toBeVisible();
+    }
+  });
+
+  test('navigates to Methods when card clicked', async ({ page }) => {
+    await page.getByText('Methods').click();
+    await expect(page).toHaveURL(/methodologies/);
+  });
+});


### PR DESCRIPTION
## Summary
- disable auth when Playwright launches the dev server
- document how to run Playwright tests with auth disabled

## Testing
- `npm run test:e2e` *(fails: playwright not found)*